### PR TITLE
#37 Fix title description text in 'What can you do' block [Home page] 

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -23,7 +23,7 @@
   },
   "whatCanYouDo": {
     "title": "What can you do",
-    "description": "Whether you’re looking for a tutor or to looking become one – you’ve come to the right place.",
+    "description": "Whether you’re looking for a tutor or looking to become one – you’ve come to the right place.",
     "learn": {
       "title": "Learn from experts",
       "description": "Learning from experts is a shortcut to mastery. Their knowledge and experience can guide you, unlocking your potential. Don't put off until tomorrow. Embrace it! 🌟",


### PR DESCRIPTION
## Description
This pull request addresses bugfix #37 by fixing the title description text in the 'What can you do' block on the home page to correspond with the mockup.

## Changes Made
- Updated the title description text in `guest-home-page.json` to match the mockup.

## Screenshot
<img width="1100" alt="Знімок екрана 2024-07-12 о 09 01 05" src="https://github.com/user-attachments/assets/d4642e7b-25ce-495f-b734-0b927a5f8aa7">
