### PR TITLE
Feature tutors/students registration pop up

### DIFF
--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -13,6 +13,7 @@ interface PopupDialogProps {
   timerId: NodeJS.Timeout | null
   closeModalAfterDelay: (delay?: number) => void
   closeModal: (delay?: number) => void
+  showCloseButton?: boolean
 }
 
 const PopupDialog: FC<PopupDialogProps> = ({
@@ -20,7 +21,8 @@ const PopupDialog: FC<PopupDialogProps> = ({
   paperProps,
   timerId,
   closeModalAfterDelay,
-  closeModal
+  closeModal,
+  showCloseButton = true
 }) => {
   const { isMobile } = useBreakpoints()
 
@@ -46,9 +48,11 @@ const PopupDialog: FC<PopupDialogProps> = ({
         onMouseOver={handleMouseOver}
         sx={styles.box}
       >
-        <IconButton onClick={handleClose} sx={styles.icon}>
-          <CloseIcon />
-        </IconButton>
+        {showCloseButton && (
+          <IconButton onClick={handleClose} sx={styles.icon}>
+            <CloseIcon />
+          </IconButton>
+        )}
         <Box sx={styles.contentWraper}>{content}</Box>
       </Box>
     </Dialog>

--- a/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
+++ b/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
@@ -1,0 +1,88 @@
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import { useTranslation } from 'react-i18next'
+
+import GoogleLogin from '~/containers/guest-home-page/google-login/GoogleLogin'
+
+import SignupForm from '../signup-form/SignupForm'
+import useForm from '~/hooks/use-form'
+import { useSignUpMutation } from '~/services/auth-service'
+import { useModalContext } from '~/context/modal-context'
+import { useSnackBarContext } from '~/context/snackbar-context'
+import {
+  email,
+  firstName,
+  lastName,
+  password,
+  confirmPassword
+} from '~/utils/validations/login'
+
+import signupStudentImg from '~/assets/img/signup-dialog/student.svg'
+import signupTutorImg from '~/assets/img/signup-dialog/tutor.svg'
+import { snackbarVariants } from '~/constants'
+
+import styles from '~/containers/guest-home-page/signup-dialog/SignupDialog.styles'
+
+const SignupDialog = ({ isTutor = true }) => {
+  const { t } = useTranslation()
+  const { closeModal } = useModalContext()
+  const { setAlert } = useSnackBarContext()
+  const [signupUser] = useSignUpMutation()
+
+  const { handleSubmit, handleInputChange, handleBlur, data, errors } = useForm(
+    {
+      onSubmit: async () => {
+        try {
+          await signupUser(data).unwrap()
+          closeModal()
+        } catch (e) {
+          setAlert({
+            severity: snackbarVariants.error,
+            message: `errors.${e.data.code}`
+          })
+        }
+      },
+      initialValues: {
+        email: '',
+        password: '',
+        confirmPassword: '',
+        firstName: '',
+        lastName: '',
+        agreeCheckBox: false
+      },
+      validations: { email, firstName, lastName, password, confirmPassword }
+    }
+  )
+
+  return (
+    <Box sx={styles.root}>
+      <Box sx={styles.imgContainer}>
+        <Box
+          alt='login'
+          component='img'
+          src={isTutor ? signupTutorImg : signupStudentImg}
+          sx={styles.img}
+        />
+      </Box>
+
+      <Box sx={styles.formContainer}>
+        <Typography sx={styles.title} variant='h2'>
+          {t(isTutor ? 'signup.head.tutor' : 'signup.head.student')}
+        </Typography>
+        <Box sx={styles.form}>
+          <SignupForm
+            data={data}
+            errors={errors}
+            handleBlur={handleBlur}
+            handleChange={handleInputChange}
+            handleSubmit={handleSubmit}
+            isTutor={isTutor}
+          />
+          <GoogleLogin buttonWidth={styles.form.maxWidth} type={'signup'} />
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export default SignupDialog

--- a/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
+++ b/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import PropTypes from 'prop-types'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import IconButton from '@mui/material/IconButton'
@@ -60,7 +61,6 @@ const SignupDialog = ({ isTutor = true }) => {
     Object.values(data).some(
       (value) => typeof value === 'string' && value.trim() !== ''
     )
-
   const handleClose = () => {
     if (!hasFilledFields()) {
       closeModal()
@@ -70,12 +70,26 @@ const SignupDialog = ({ isTutor = true }) => {
     }
   }
 
+  const stopPropagation = (e) => e.stopPropagation()
+
+  const emptyFunction = () => {}
+
+  let signupImgSrc
+  let signupHeadText
+  if (isTutor) {
+    signupImgSrc = signupTutorImg
+    signupHeadText = 'signup.head.tutor'
+  } else {
+    signupImgSrc = signupStudentImg
+    signupHeadText = 'signup.head.student'
+  }
+
   return (
     <PopupDialog
       closeModal={closeModal}
-      closeModalAfterDelay={() => {}}
+      closeModalAfterDelay={emptyFunction}
       content={
-        <Box onClick={(e) => e.stopPropagation()} sx={styles.root}>
+        <Box onClick={stopPropagation} sx={styles.root}>
           <IconButton
             aria-label='close'
             data-testid='close-button'
@@ -88,14 +102,14 @@ const SignupDialog = ({ isTutor = true }) => {
             <Box
               alt='login'
               component='img'
-              src={isTutor ? signupTutorImg : signupStudentImg}
+              src={signupImgSrc}
               sx={styles.img}
             />
           </Box>
 
           <Box sx={styles.formContainer}>
             <Typography sx={styles.title} variant='h2'>
-              {t(isTutor ? 'signup.head.tutor' : 'signup.head.student')}
+              {t(signupHeadText)}
             </Typography>
             <Box sx={styles.form}>
               <SignupForm
@@ -127,6 +141,10 @@ const SignupDialog = ({ isTutor = true }) => {
       timerId={null}
     />
   )
+}
+
+SignupDialog.propTypes = {
+  isTutor: PropTypes.bool
 }
 
 export default SignupDialog

--- a/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
+++ b/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
@@ -1,9 +1,10 @@
+import { useState } from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
+import IconButton from '@mui/material/IconButton'
+import CloseIcon from '@mui/icons-material/Close'
 import { useTranslation } from 'react-i18next'
-
 import GoogleLogin from '~/containers/guest-home-page/google-login/GoogleLogin'
-
 import SignupForm from '../signup-form/SignupForm'
 import useForm from '~/hooks/use-form'
 import { useSignUpMutation } from '~/services/auth-service'
@@ -16,18 +17,19 @@ import {
   password,
   confirmPassword
 } from '~/utils/validations/login'
-
 import signupStudentImg from '~/assets/img/signup-dialog/student.svg'
 import signupTutorImg from '~/assets/img/signup-dialog/tutor.svg'
 import { snackbarVariants } from '~/constants'
-
 import styles from '~/containers/guest-home-page/signup-dialog/SignupDialog.styles'
+import ConfirmDialog from '~/components/confirm-dialog/ConfirmDialog'
+import PopupDialog from '~/components/popup-dialog/PopupDialog'
 
 const SignupDialog = ({ isTutor = true }) => {
   const { t } = useTranslation()
   const { closeModal } = useModalContext()
   const { setAlert } = useSnackBarContext()
   const [signupUser] = useSignUpMutation()
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false)
 
   const { handleSubmit, handleInputChange, handleBlur, data, errors } = useForm(
     {
@@ -43,45 +45,87 @@ const SignupDialog = ({ isTutor = true }) => {
         }
       },
       initialValues: {
-        email: '',
-        password: '',
+        agreeCheckBox: false,
         confirmPassword: '',
+        email: '',
         firstName: '',
         lastName: '',
-        agreeCheckBox: false
+        password: ''
       },
       validations: { email, firstName, lastName, password, confirmPassword }
     }
   )
 
-  return (
-    <Box sx={styles.root}>
-      <Box sx={styles.imgContainer}>
-        <Box
-          alt='login'
-          component='img'
-          src={isTutor ? signupTutorImg : signupStudentImg}
-          sx={styles.img}
-        />
-      </Box>
+  const hasFilledFields = () =>
+    Object.values(data).some(
+      (value) => typeof value === 'string' && value.trim() !== ''
+    )
 
-      <Box sx={styles.formContainer}>
-        <Typography sx={styles.title} variant='h2'>
-          {t(isTutor ? 'signup.head.tutor' : 'signup.head.student')}
-        </Typography>
-        <Box sx={styles.form}>
-          <SignupForm
-            data={data}
-            errors={errors}
-            handleBlur={handleBlur}
-            handleChange={handleInputChange}
-            handleSubmit={handleSubmit}
-            isTutor={isTutor}
+  const handleClose = () => {
+    if (!hasFilledFields()) {
+      closeModal()
+      window.history.back()
+    } else {
+      setShowConfirmDialog(true)
+    }
+  }
+
+  return (
+    <PopupDialog
+      closeModal={closeModal}
+      closeModalAfterDelay={() => {}}
+      content={
+        <Box onClick={(e) => e.stopPropagation()} sx={styles.root}>
+          <IconButton
+            aria-label='close'
+            data-testid='close-button'
+            onClick={handleClose}
+            sx={styles.closeButton}
+          >
+            <CloseIcon />
+          </IconButton>
+          <Box sx={styles.imgContainer}>
+            <Box
+              alt='login'
+              component='img'
+              src={isTutor ? signupTutorImg : signupStudentImg}
+              sx={styles.img}
+            />
+          </Box>
+
+          <Box sx={styles.formContainer}>
+            <Typography sx={styles.title} variant='h2'>
+              {t(isTutor ? 'signup.head.tutor' : 'signup.head.student')}
+            </Typography>
+            <Box sx={styles.form}>
+              <SignupForm
+                data={data}
+                errors={errors}
+                handleBlur={handleBlur}
+                handleChange={handleInputChange}
+                handleSubmit={handleSubmit}
+                isTutor={isTutor}
+              />
+              <GoogleLogin buttonWidth={styles.form.maxWidth} type='signup' />
+            </Box>
+          </Box>
+
+          <ConfirmDialog
+            message='Are you certain you want to close? Any unsaved changes will be lost.'
+            onConfirm={() => {
+              setShowConfirmDialog(false)
+              closeModal()
+            }}
+            onDismiss={() => setShowConfirmDialog(false)}
+            open={showConfirmDialog}
+            title='Please confirm'
           />
-          <GoogleLogin buttonWidth={styles.form.maxWidth} type={'signup'} />
         </Box>
-      </Box>
-    </Box>
+      }
+      paperProps={{}}
+      showCloseButton={false}
+      timerId={null}
+    />
   )
 }
 

--- a/src/containers/guest-home-page/signup-dialog/SignupDialog.styles.js
+++ b/src/containers/guest-home-page/signup-dialog/SignupDialog.styles.js
@@ -1,0 +1,49 @@
+import { scrollbar } from '~/styles/app-theme/custom-scrollbar'
+
+const style = {
+  root: {
+    maxWidth: { sm: 'sm', md: 'md', lg: 'lg' },
+    mt: { xs: '56px', sm: 0 },
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: { lg: '122px', md: '40px' },
+    maxHeight: { xs: 'calc(100vh - 56px)', sm: 'calc(100vh - 64px)' }
+  },
+  imgContainer: {
+    width: '450px',
+    maxWidth: { md: '50%', lg: '450px' },
+    maxHeight: 'inherit',
+    display: { xs: 'none', md: 'flex' },
+    pl: { lg: '96px', md: '30px' }
+  },
+  img: {
+    objectFit: 'contain',
+    width: '100%'
+  },
+  formContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxHeight: 'inherit',
+    boxSizing: 'border-box',
+    borderTop: { xs: '1px solid', sm: 'none' },
+    borderColor: { xs: 'primary.100' },
+    pt: { xs: '24px', sm: '64px' },
+    pl: { xs: '8px', sm: '96px', md: '16px' }
+  },
+  title: {
+    mb: '16px',
+    fontSize: '40px',
+    lineHeight: '48px'
+  },
+  form: {
+    overflow: 'auto',
+    maxWidth: { xs: '315px', md: '343px' },
+    pt: '16px',
+    pr: { xs: '8px', sm: '96px', md: '80px', lg: '96px' },
+    pb: { xs: '24px', sm: '64px' },
+    ...scrollbar
+  }
+}
+
+export default style

--- a/src/containers/guest-home-page/signup-dialog/SignupDialog.styles.js
+++ b/src/containers/guest-home-page/signup-dialog/SignupDialog.styles.js
@@ -43,6 +43,16 @@ const style = {
     pr: { xs: '8px', sm: '96px', md: '80px', lg: '96px' },
     pb: { xs: '24px', sm: '64px' },
     ...scrollbar
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 15,
+    right: 20,
+    color: 'black',
+    backgroundColor: 'white',
+    '&:hover': {
+      backgroundColor: 'transparent'
+    }
   }
 }
 

--- a/src/containers/guest-home-page/signup-dialog/SignupDialog.styles.js
+++ b/src/containers/guest-home-page/signup-dialog/SignupDialog.styles.js
@@ -1,10 +1,15 @@
 import { scrollbar } from '~/styles/app-theme/custom-scrollbar'
 
+const sharedMaxHeight = 'inherit'
+const sharedDisplayFlex = 'flex'
+const sharedPt = { xs: '24px', sm: '64px' }
+const sharedPl = { lg: '96px', md: '16px' }
+
 const style = {
   root: {
     maxWidth: { sm: 'sm', md: 'md', lg: 'lg' },
     mt: { xs: '56px', sm: 0 },
-    display: 'flex',
+    display: sharedDisplayFlex,
     justifyContent: 'space-between',
     alignItems: 'center',
     gap: { lg: '122px', md: '40px' },
@@ -13,23 +18,23 @@ const style = {
   imgContainer: {
     width: '450px',
     maxWidth: { md: '50%', lg: '450px' },
-    maxHeight: 'inherit',
-    display: { xs: 'none', md: 'flex' },
-    pl: { lg: '96px', md: '30px' }
+    maxHeight: sharedMaxHeight,
+    display: { xs: 'none', md: sharedDisplayFlex },
+    pl: { ...sharedPl, md: '30px' }
   },
   img: {
     objectFit: 'contain',
     width: '100%'
   },
   formContainer: {
-    display: 'flex',
+    display: sharedDisplayFlex,
     flexDirection: 'column',
-    maxHeight: 'inherit',
+    maxHeight: sharedMaxHeight,
     boxSizing: 'border-box',
     borderTop: { xs: '1px solid', sm: 'none' },
     borderColor: { xs: 'primary.100' },
-    pt: { xs: '24px', sm: '64px' },
-    pl: { xs: '8px', sm: '96px', md: '16px' }
+    pt: sharedPt,
+    pl: { xs: '8px', ...sharedPl, sm: '96px' }
   },
   title: {
     mb: '16px',
@@ -41,7 +46,7 @@ const style = {
     maxWidth: { xs: '315px', md: '343px' },
     pt: '16px',
     pr: { xs: '8px', sm: '96px', md: '80px', lg: '96px' },
-    pb: { xs: '24px', sm: '64px' },
+    pb: sharedPt,
     ...scrollbar
   },
   closeButton: {

--- a/src/containers/guest-home-page/signup-form/SignupForm.jsx
+++ b/src/containers/guest-home-page/signup-form/SignupForm.jsx
@@ -59,19 +59,8 @@ const SignupForm = ({
   const { authLoading } = useSelector((state) => state.appMain)
   const { t } = useTranslation()
 
-  let passwordType
-  if (showPassword) {
-    passwordType = 'text'
-  } else {
-    passwordType = 'password'
-  }
-
-  let confirmPasswordType
-  if (showConfirmPassword) {
-    confirmPasswordType = 'text'
-  } else {
-    confirmPasswordType = 'password'
-  }
+  const passwordType = showPassword ? 'text' : 'password'
+  const confirmPasswordType = showConfirmPassword ? 'text' : 'password'
 
   return (
     <Box component='form' onSubmit={handleSubmit} sx={styles.form}>

--- a/src/containers/guest-home-page/signup-form/SignupForm.jsx
+++ b/src/containers/guest-home-page/signup-form/SignupForm.jsx
@@ -1,104 +1,129 @@
 import { useTranslation } from 'react-i18next'
 import useInputVisibility from '~/hooks/use-input-visibility'
 import { useSelector } from 'react-redux'
-
 import Box from '@mui/material/Box'
-
 import Typography from '@mui/material/Typography'
 import { Checkbox, FormControlLabel } from '@mui/material'
-
 import AppTextField from '~/components/app-text-field/AppTextField'
 import AppButton from '~/components/app-button/AppButton'
-
 import { styles } from '~/containers/guest-home-page/signup-form/SignupForm.styles'
 
-const SignupForm = ({
-  handleSubmit,
-  handleChange,
+const useInputVisibilityWithErrors = (error) => {
+  return useInputVisibility(error)
+}
+
+const InputField = ({
+  error,
   handleBlur,
+  handleChange,
+  id,
+  label,
+  type,
+  value,
+  visibilityProps
+}) => {
+  const { t } = useTranslation()
+
+  return (
+    <AppTextField
+      InputProps={visibilityProps}
+      data-testid={id}
+      errorMsg={t(error)}
+      fullWidth
+      label={t(label)}
+      onBlur={handleBlur(id)}
+      onChange={handleChange(id)}
+      required
+      size='large'
+      sx={{ mb: '5px' }}
+      type={type}
+      value={value}
+    />
+  )
+}
+
+const SignupForm = ({
   data,
-  errors
+  errors,
+  handleBlur,
+  handleChange,
+  handleSubmit
 }) => {
   const { inputVisibility: passwordVisibility, showInputText: showPassword } =
-    useInputVisibility(errors.password)
+    useInputVisibilityWithErrors(errors.password)
   const {
     inputVisibility: confirmPasswordVisibility,
     showInputText: showConfirmPassword
-  } = useInputVisibility(errors.password)
+  } = useInputVisibilityWithErrors(errors.confirmPassword)
 
   const { authLoading } = useSelector((state) => state.appMain)
-
   const { t } = useTranslation()
+
+  let passwordType
+  if (showPassword) {
+    passwordType = 'text'
+  } else {
+    passwordType = 'password'
+  }
+
+  let confirmPasswordType
+  if (showConfirmPassword) {
+    confirmPasswordType = 'text'
+  } else {
+    confirmPasswordType = 'password'
+  }
 
   return (
     <Box component='form' onSubmit={handleSubmit} sx={styles.form}>
       <Box sx={styles.nameBox}>
-        <AppTextField
-          autoFocus
-          data-testid={'firstName'}
-          errorMsg={t(errors.firstName)}
-          fullWidth
-          label={t('common.labels.firstName')}
-          onBlur={handleBlur('firstName')}
-          onChange={handleChange('firstName')}
-          required
-          size='large'
-          sx={{ mb: '5px' }}
+        <InputField
+          error={errors.firstName}
+          handleBlur={handleBlur}
+          handleChange={handleChange}
+          id='firstName'
+          label='common.labels.firstName'
           type='text'
           value={data.firstName}
         />
-        <AppTextField
-          autoFocus
-          data-testid={'lastName'}
-          errorMsg={t(errors.lastName)}
-          fullWidth
-          label={t('common.labels.lastName')}
-          onBlur={handleBlur('lastName')}
-          onChange={handleChange('lastName')}
-          required
-          size='large'
-          sx={{ mb: '5px' }}
+        <InputField
+          error={errors.lastName}
+          handleBlur={handleBlur}
+          handleChange={handleChange}
+          id='lastName'
+          label='common.labels.lastName'
           type='text'
           value={data.lastName}
         />
       </Box>
-      <AppTextField
-        data-testid={'email'}
-        errorMsg={t(errors.email)}
-        fullWidth
-        label={t('common.labels.email')}
-        onBlur={handleBlur('email')}
-        onChange={handleChange('email')}
-        required
-        size='large'
-        sx={{ mb: '5px' }}
+      <InputField
+        error={errors.email}
+        handleBlur={handleBlur}
+        handleChange={handleChange}
+        id='email'
+        label='common.labels.email'
         type='email'
         value={data.email}
       />
-
-      <AppTextField
-        InputProps={passwordVisibility}
-        errorMsg={t(errors.password)}
-        fullWidth
-        label={t('common.labels.password')}
-        onBlur={handleBlur('password')}
-        onChange={handleChange('password')}
-        required
-        type={showPassword ? 'text' : 'password'}
+      <InputField
+        error={errors.password}
+        handleBlur={handleBlur}
+        handleChange={handleChange}
+        id='password'
+        label='common.labels.password'
+        type={passwordType}
         value={data.password}
+        visibilityProps={passwordVisibility}
       />
-      <AppTextField
-        InputProps={confirmPasswordVisibility}
-        errorMsg={t(errors.confirmPassword)}
-        fullWidth
-        label={t('common.labels.confirmPassword')}
-        onBlur={handleBlur('confirmPassword')}
-        onChange={handleChange('confirmPassword')}
-        required
-        type={showConfirmPassword ? 'text' : 'password'}
+      <InputField
+        error={errors.confirmPassword}
+        handleBlur={handleBlur}
+        handleChange={handleChange}
+        id='confirmPassword'
+        label='common.labels.confirmPassword'
+        type={confirmPasswordType}
         value={data.confirmPassword}
+        visibilityProps={confirmPasswordVisibility}
       />
-
       <FormControlLabel
         control={
           <Checkbox
@@ -122,7 +147,6 @@ const SignupForm = ({
         }
         sx={{ mb: '8px' }}
       />
-
       <AppButton loading={authLoading} sx={styles.loginButton} type='submit'>
         {t('common.labels.signup')}
       </AppButton>

--- a/src/containers/guest-home-page/signup-form/SignupForm.jsx
+++ b/src/containers/guest-home-page/signup-form/SignupForm.jsx
@@ -1,0 +1,133 @@
+import { useTranslation } from 'react-i18next'
+import useInputVisibility from '~/hooks/use-input-visibility'
+import { useSelector } from 'react-redux'
+
+import Box from '@mui/material/Box'
+
+import Typography from '@mui/material/Typography'
+import { Checkbox, FormControlLabel } from '@mui/material'
+
+import AppTextField from '~/components/app-text-field/AppTextField'
+import AppButton from '~/components/app-button/AppButton'
+
+import { styles } from '~/containers/guest-home-page/signup-form/SignupForm.styles'
+
+const SignupForm = ({
+  handleSubmit,
+  handleChange,
+  handleBlur,
+  data,
+  errors
+}) => {
+  const { inputVisibility: passwordVisibility, showInputText: showPassword } =
+    useInputVisibility(errors.password)
+  const {
+    inputVisibility: confirmPasswordVisibility,
+    showInputText: showConfirmPassword
+  } = useInputVisibility(errors.password)
+
+  const { authLoading } = useSelector((state) => state.appMain)
+
+  const { t } = useTranslation()
+
+  return (
+    <Box component='form' onSubmit={handleSubmit} sx={styles.form}>
+      <Box sx={styles.nameBox}>
+        <AppTextField
+          autoFocus
+          data-testid={'firstName'}
+          errorMsg={t(errors.firstName)}
+          fullWidth
+          label={t('common.labels.firstName')}
+          onBlur={handleBlur('firstName')}
+          onChange={handleChange('firstName')}
+          required
+          size='large'
+          sx={{ mb: '5px' }}
+          type='text'
+          value={data.firstName}
+        />
+        <AppTextField
+          autoFocus
+          data-testid={'lastName'}
+          errorMsg={t(errors.lastName)}
+          fullWidth
+          label={t('common.labels.lastName')}
+          onBlur={handleBlur('lastName')}
+          onChange={handleChange('lastName')}
+          required
+          size='large'
+          sx={{ mb: '5px' }}
+          type='text'
+          value={data.lastName}
+        />
+      </Box>
+      <AppTextField
+        data-testid={'email'}
+        errorMsg={t(errors.email)}
+        fullWidth
+        label={t('common.labels.email')}
+        onBlur={handleBlur('email')}
+        onChange={handleChange('email')}
+        required
+        size='large'
+        sx={{ mb: '5px' }}
+        type='email'
+        value={data.email}
+      />
+
+      <AppTextField
+        InputProps={passwordVisibility}
+        errorMsg={t(errors.password)}
+        fullWidth
+        label={t('common.labels.password')}
+        onBlur={handleBlur('password')}
+        onChange={handleChange('password')}
+        required
+        type={showPassword ? 'text' : 'password'}
+        value={data.password}
+      />
+      <AppTextField
+        InputProps={confirmPasswordVisibility}
+        errorMsg={t(errors.confirmPassword)}
+        fullWidth
+        label={t('common.labels.confirmPassword')}
+        onBlur={handleBlur('confirmPassword')}
+        onChange={handleChange('confirmPassword')}
+        required
+        type={showConfirmPassword ? 'text' : 'password'}
+        value={data.confirmPassword}
+      />
+
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={data.agreeCheckBox}
+            color='primary'
+            name='termsCheckbox'
+            onChange={handleChange('agreeCheckBox')}
+          />
+        }
+        label={
+          <Typography variant='inherit'>
+            {t('signup.iAgree')}{' '}
+            <Typography sx={{ textDecoration: 'underline' }} variant='text'>
+              {t('common.labels.terms')}
+            </Typography>{' '}
+            {t('signup.and')}{' '}
+            <Typography sx={{ textDecoration: 'underline' }} variant='text'>
+              {t('common.labels.privacyPolicy')}
+            </Typography>{' '}
+          </Typography>
+        }
+        sx={{ mb: '8px' }}
+      />
+
+      <AppButton loading={authLoading} sx={styles.loginButton} type='submit'>
+        {t('common.labels.signup')}
+      </AppButton>
+    </Box>
+  )
+}
+
+export default SignupForm

--- a/src/containers/guest-home-page/signup-form/SignupForm.styles.js
+++ b/src/containers/guest-home-page/signup-form/SignupForm.styles.js
@@ -9,7 +9,7 @@ export const styles = {
   },
   loginButton: {
     width: '100%',
-    py: '14px'
+    py: '10px'
   },
   forgotPass: {
     cursor: 'pointer',

--- a/src/containers/guest-home-page/signup-form/SignupForm.styles.js
+++ b/src/containers/guest-home-page/signup-form/SignupForm.styles.js
@@ -1,0 +1,32 @@
+export const styles = {
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: { sm: '340px' }
+  },
+  input: {
+    maxWidth: '343px'
+  },
+  loginButton: {
+    width: '100%',
+    py: '14px'
+  },
+  forgotPass: {
+    cursor: 'pointer',
+    textDecoration: 'none',
+    color: 'primary.900',
+    '&:hover': {
+      textDecoration: 'underline'
+    },
+    '&:focus': {
+      outline: '2px solid',
+      borderRadius: '2px'
+    },
+    mb: '20px',
+    alignSelf: 'end'
+  },
+  nameBox: {
+    display: 'flex',
+    gap: '16px'
+  }
+}


### PR DESCRIPTION
## Video 

https://github.com/user-attachments/assets/a466829a-4e76-48fd-a1f1-8397f495dca6

## 
1. When a Guest clicks on the ”Become a tutor” button on the home page, the “Sign up as a tutor” pop-up appears.
2. The “Sign up as a tutor” pop-up has three adaptations: for desktop/laptop, tablet, and mobile versions. The “Sign up as a tutor” pop-up in desktop/laptop version contains two parts

## Screenshot 

![5258378819440597480](https://github.com/user-attachments/assets/c168593a-e4b1-421f-855b-9c86c885c2ce)


3. The “Sign up as a tutor” pop-up has the close button in the upper right corner.
4. When a Guest clicks on the close button and no text field has been filled with data, the “Sign up as a student” pop-up closes, and the Guest returns to the last viewed page.
5. When a Guest clicks the close button, and at least one text field has been filled with data, a confirmation pop-up appears (“Please confirm” title, “Are you certain you want to close? Any unsaved changes will be lost.” description).
6. If a Guest chooses “No,” the confirmation pop-up closes, and he/she remains on the “Sign up as a student” pop-up.
7. If a Guest chooses “Yes,” the “Sign up as a student” pop-up closes, and the Guest goes to the last viewed page.
8. When a User clicks outside the “Sign up as a student” pop-up field, nothing happens.

