### PR TITLE
 Update 'Already have a Space2Study account?' to match requirements

### DIFF
--- a/src/constants/translations/en/signup.json
+++ b/src/constants/translations/en/signup.json
@@ -7,7 +7,7 @@
   "and": "and",
   "googleButton": "Sign up with Google",
   "continue": "or continue",
-  "haveAccount": "Already have a tutor account?",
+  "haveAccount": "Already have a Space2Study account?",
   "joinUs": "Login!",
   "confirmEmailTitle": "Your email address needs to be verified",
   "confirmEmailMessage": "We sent a confirmation email to: ",


### PR DESCRIPTION
## Result
The text under "Sign Up with Google" button is "Already have a Space2Study account? Log In!" is matching to mockup.