### PR TITLE
Feature/102/add photo and select on subject step

### DIFF
--- a/src/components/app-select/AppSelect.styles.ts
+++ b/src/components/app-select/AppSelect.styles.ts
@@ -18,5 +18,11 @@ export const styles = {
       lineHeight: 'inherit',
       color: 'primary.500'
     }
+  },
+  clearIcon: {
+    position: 'absolute',
+    right: '8px',
+    top: '50%',
+    transform: 'translateY(-50%)'
   }
 }

--- a/src/components/app-select/AppSelect.tsx
+++ b/src/components/app-select/AppSelect.tsx
@@ -7,15 +7,21 @@ import Box from '@mui/material/Box'
 
 import InputLabel from '@mui/material/InputLabel'
 import Typography from '@mui/material/Typography'
+import IconButton from '@mui/material/IconButton'
+import ClearIcon from '@mui/icons-material/Clear'
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 
 import { SelectFieldType } from '~/types'
 import { styles } from '~/components/app-select/AppSelect.styles'
+
+const NoIcon = () => null
 
 interface AppSelectProps<T> extends SelectProps<T> {
   setValue: (value: T) => void
   value: T
   fields: SelectFieldType<T>[]
   selectTitle?: string
+  hideTriangleIcon?: boolean
 }
 
 const AppSelect = <T,>({
@@ -25,12 +31,17 @@ const AppSelect = <T,>({
   selectTitle,
   sx,
   label,
+  hideTriangleIcon,
   ...props
 }: AppSelectProps<T>) => {
   const { t } = useTranslation()
 
   const changeValue = (event: SelectChangeEvent<T>) =>
     setValue(event.target.value as T)
+
+  const handleClear = () => {
+    setValue('' as T)
+  }
 
   const fieldsList = fields.map(({ title, value }) => {
     if (typeof value === 'string' || typeof value === 'number') {
@@ -61,6 +72,19 @@ const AppSelect = <T,>({
           sx={styles.selectField}
           value={value}
           {...props}
+          IconComponent={hideTriangleIcon && value ? NoIcon : ArrowDropDownIcon}
+          endAdornment={
+            hideTriangleIcon &&
+            value && (
+              <IconButton
+                aria-label='clear'
+                onClick={handleClear}
+                sx={styles.clearIcon}
+              >
+                <ClearIcon />
+              </IconButton>
+            )
+          }
         >
           {fieldsList}
         </Select>

--- a/src/components/title-with-description/TitleWithDescription.tsx
+++ b/src/components/title-with-description/TitleWithDescription.tsx
@@ -24,7 +24,6 @@ const TitleWithDescription = ({
   isDescriptionTooltip = false
 }: TitleWithDescriptionProps) => {
   const [tooltipVisible, setTooltipVisible] = useState<boolean>(false)
-
   const handleTooltip = () => setTooltipVisible((prevState) => !prevState)
 
   return (

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
 import { styles } from '~/containers/tutor-home-page/subjects-step/SubjectsStep.styles'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
@@ -5,12 +6,54 @@ import subjectsImage from '~/assets/img/tutor-home-page/become-tutor/study-categ
 import { useTranslation } from 'react-i18next'
 import AppSelect from '~/components/app-select/AppSelect'
 import AppButton from '~/components/app-button/AppButton'
-import { useState } from 'react'
-import { categoriesMock, languagesMock } from './constants'
+import { categoryService } from '~/services/category-service'
+import { subjectService } from '~/services/subject-service'
 
 const SubjectsStep = ({ btnsBox }) => {
   const { t } = useTranslation()
+
+  const [selectedCategory, setSelectedCategory] = useState('')
+  const [selectedSubject, setSelectedSubject] = useState('')
+  const [categoryOptions, setCategoryOptions] = useState([])
+  const [subjectOptions, setSubjectOptions] = useState([])
   const [loading] = useState(false)
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await categoryService.getCategoriesNames()
+        const categories = response.data.map((category) => ({
+          title: `${category.name} Category: ${category.name}`,
+          value: category.name
+        }))
+        setCategoryOptions(categories)
+      } catch (error) {
+        console.error('Error fetching categories:', error)
+      }
+    }
+
+    fetchCategories()
+  }, [])
+
+  const handleCategoryChange = async (value) => {
+    setSelectedCategory(value)
+
+    try {
+      const response = await subjectService.getSubjectsNames(value)
+      const subjects = response.data.map((subject) => ({
+        title: `${subject.name} Category: ${value}`,
+        value: subject.name
+      }))
+      setSubjectOptions(subjects)
+    } catch (error) {
+      console.error('Error fetching subjects:', error)
+    }
+    setSelectedSubject('')
+  }
+
+  const handleSubjectChange = (value) => {
+    setSelectedSubject(value)
+  }
 
   return (
     <Box sx={styles.container}>
@@ -24,14 +67,20 @@ const SubjectsStep = ({ btnsBox }) => {
         />
         <Box sx={styles.selectContainer}>
           <AppSelect
-            fields={languagesMock}
+            fields={categoryOptions}
+            hideTriangleIcon
             label={t('becomeTutor.categories.mainSubjectsLabel')}
+            setValue={handleCategoryChange}
             sx={styles.select}
+            value={selectedCategory}
           />
           <AppSelect
-            fields={categoriesMock}
+            fields={subjectOptions}
+            hideTriangleIcon
             label={t('becomeTutor.categories.subjectLabel')}
+            setValue={handleSubjectChange}
             sx={styles.select}
+            value={selectedSubject}
           />
         </Box>
         <AppButton

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -1,13 +1,48 @@
 import Box from '@mui/material/Box'
-
 import { styles } from '~/containers/tutor-home-page/subjects-step/SubjectsStep.styles'
+import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
+import subjectsImage from '~/assets/img/tutor-home-page/become-tutor/study-category.svg'
+import { useTranslation } from 'react-i18next'
+import AppSelect from '~/components/app-select/AppSelect'
+import AppButton from '~/components/app-button/AppButton'
+import { useState } from 'react'
+import { categoriesMock, languagesMock } from './constants'
 
 const SubjectsStep = ({ btnsBox }) => {
+  const { t } = useTranslation()
+  const [loading] = useState(false)
+
   return (
     <Box sx={styles.container}>
-      <Box sx={styles.rigthBox}>
-        Subjects step
-        {btnsBox}
+      <Box sx={styles.imgContainer}>
+        <Box component='img' src={subjectsImage} sx={styles.img} />
+      </Box>
+      <Box sx={styles.rightBox}>
+        <TitleWithDescription
+          sx={styles.titleWithDescription}
+          title={t('becomeTutor.categories.title')}
+        />
+        <Box sx={styles.selectContainer}>
+          <AppSelect
+            fields={languagesMock}
+            label={t('becomeTutor.categories.mainSubjectsLabel')}
+            sx={styles.select}
+          />
+          <AppSelect
+            fields={categoriesMock}
+            label={t('becomeTutor.categories.subjectLabel')}
+            sx={styles.select}
+          />
+        </Box>
+        <AppButton
+          disabled={false}
+          loading={loading}
+          sx={styles.submitButton}
+          title='ok'
+        >
+          {t('becomeTutor.categories.btnText')}
+        </AppButton>
+        <Box sx={styles.btnsBoxWrapper}>{btnsBox}</Box>
       </Box>
     </Box>
   )

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -19,7 +19,7 @@ const SubjectsStep = ({ btnsBox }) => {
       </Box>
       <Box sx={styles.rightBox}>
         <TitleWithDescription
-          sx={styles.titleWithDescription}
+          style={styles.titleWithDescription}
           title={t('becomeTutor.categories.title')}
         />
         <Box sx={styles.selectContainer}>

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -8,5 +8,48 @@ export const styles = {
     height: { sm: '485px' },
     paddingBottom: { xs: '30px', sm: '0px' },
     ...fadeAnimation
+  },
+  imgContainer: {
+    display: 'flex',
+    flex: 1,
+    maxWidth: '432px',
+    aspectRatio: { xs: '4/3', sm: 'auto' },
+    pb: { xs: '16px', sm: '52px' }
+  },
+  img: {
+    width: '100%',
+    m: { sm: 0, xs: '0 auto' }
+  },
+  rightBox: {
+    maxWidth: '600px',
+    width: '50%',
+    display: 'flex',
+    flexDirection: 'column',
+    m: { md: 0, xs: '0 auto' },
+    pt: 0
+  },
+  titleWithDescription: {
+    wrapper: {
+      textAlign: 'start',
+      m: 0
+    },
+    description: {
+      typography: 'body2',
+      mb: '20px'
+    }
+  },
+  selectContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '20px'
+  },
+  select: {
+    width: '100%'
+  },
+  submitButton: {
+    mt: '20px'
+  },
+  btnsBoxWrapper: {
+    mt: 'auto'
   }
 }

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -30,7 +30,7 @@ export const styles = {
   },
   titleWithDescription: {
     wrapper: {
-      textAlign: 'start',
+      textAlign: 'left',
       m: 0
     },
     description: {


### PR DESCRIPTION
Add photo and select field of categories and subjects on Subjects step for a tutor stepper

![Screenshot_12](https://github.com/user-attachments/assets/059cab8c-b784-4b56-8012-ed719846d02e)


- [x]  When user clicks on field with categories they should be fetched from server
- [x]  When user chose a category and clicked on subjects select it should fetch all subjects of this category
- [x]  When user clicks on criss-cross of select it should clear it