### PR TITLE
Fix description not corresponded to the mockup in the “Photo” page

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -24,7 +24,7 @@
     "imageAlt": "Your photo",
     "button": "Upload your profile photo",
     "placeholder": "Photo Preview",
-    "description": "Velit officia consequat duis enim velit mollit. Exercitation veniam consequat sunt nostrud amet.",
+    "description": "Please upload a photo that represents you and helps others recogize you.",
     "typeError": "Wrong file type. Only .png/.jpg/.jpeg files are allowed.",
     "fileSizeError": "Size for one file cannot be more than 10MB."
   },


### PR DESCRIPTION
**Description**: The description is not corresponded to the mockup in the “Photo” page on the ‘Become a student’ pop-up. The issue is reproduced with a Tutor role.


 "description": "Velit officia consequat duis enim velit mollit. Exercitation veniam consequat sunt nostrud amet.",
 ## -> 
 "description": "Please upload a photo that represents you and helps others recogize you.",