### PR TITLE
Fixed description is not corresponded to the mockup on the “General” page

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -1,6 +1,6 @@
 {
   "generalInfo": {
-    "title": "Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint.",
+    "title": "Please complete the registration form for the best possible experience.",
     "textFieldLabel": "Describe in short your professional status",
     "helperText": "Inputs with the * sign are required"
   },


### PR DESCRIPTION
**Description**: The description is not corresponded to the mockup in the “General” page of the ‘Become a student’ pop-up. The issue is reproduced with a Tutor role.

 "title": "Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint.",
 ## ->
 "title": "Please complete the registration form for the best possible experience.",