### PR TITLE
Fix text in 'Interests' page of 'Become a student' pop-up to match mockup

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -13,7 +13,7 @@
     "autocompleteLabel": "Your native language"
   },
   "categories": {
-    "title": "Velit officia consequat duis enim velit mollit. Other categories you can add in your account settings later.",
+    "title": "Please choose the main subjects based on the category. You can add others later.",
     "mainSubjectsLabel": "Main Tutoring Category",
     "subjectLabel": "Subject",
     "btnText": "Add one more subject",


### PR DESCRIPTION
**Description**: The description is not corresponded to the mockup in the “Interests” page on the ‘Become a student’ pop-up. The issue is reproduced with a Tutor role in the "Subjects" page.

 "title": "Velit officia consequat duis enim velit mollit. Other categories you can add in your account settings later.",
 ## ->
 "title": "Please choose the main subjects based on the category. You can add others later.",
