### PR TITLE
Implement view for lesson

### DIFF
--- a/src/containers/my-resources/lesson-detail/LessonDetail.tsx
+++ b/src/containers/my-resources/lesson-detail/LessonDetail.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { ResourceServiceMock as ResourceService } from '../lesson-list/resource-service.mock'
+import Loader from '~/components/loader/Loader'
+import { Lesson } from '~/types/my-resources/types/lesson.types'
+import { Box, Typography } from '@mui/material'
+import { styles } from '~/containers/my-resources/add-resource-modal/AddResourceModal.styles'
+
+const LessonDetail = () => {
+  const { t } = useTranslation()
+  const { lessonId } = useParams<{ lessonId: string }>()
+  const [lesson, setLesson] = useState<Lesson | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    const fetchLesson = async () => {
+      if (lessonId) {
+        try {
+          const fetchedLesson: Lesson | null =
+            await ResourceService.getLesson(lessonId)
+          setLesson(fetchedLesson)
+        } catch (error: unknown) {
+          console.error('Error fetching lesson:', error)
+        } finally {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchLesson().catch((error: unknown) => console.error(error))
+  }, [lessonId])
+
+  if (loading) {
+    return <Loader pageLoad />
+  }
+
+  if (!lesson) {
+    return <div>{t('lessons.noLessonFound')}</div>
+  }
+
+  return (
+    <Box sx={styles.root}>
+      <Typography sx={styles.title} variant='h1'>
+        <Link
+          style={{ textDecoration: 'none', color: 'inherit' }}
+          to={`/edit-lesson/${lesson.id}`}
+        >
+          {lesson.title}
+        </Link>
+      </Typography>
+      {lesson.description && (
+        <Typography sx={styles.root} variant='body1'>
+          {lesson.description}
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
+export default LessonDetail

--- a/src/containers/my-resources/lesson-list/LessonList.tsx
+++ b/src/containers/my-resources/lesson-list/LessonList.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ResourceServiceMock as ResourceService } from '../lesson-list/resource-service.mock'
+import Loader from '~/components/loader/Loader'
+import { Lesson } from '~/types/my-resources/types/lesson.types'
+import { Box } from '@mui/material'
+import { styles } from '~/containers/my-resources/add-resource-modal/AddResourceModal.styles'
+
+const LessonList = () => {
+  const [lessons, setLessons] = useState<Lesson[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchLessons = async () => {
+      try {
+        const fetchedLessons: Lesson[] = await ResourceService.getLessons()
+        setLessons(fetchedLessons)
+      } catch (error) {
+        console.error('Error fetching lessons:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchLessons().catch(console.error)
+  }, [])
+
+  if (loading) {
+    return <Loader pageLoad />
+  }
+
+  return (
+    <Box sx={styles.root}>
+      <ul>
+        {lessons.map((lesson) => (
+          <li key={lesson.id}>
+            <Link
+              style={{ color: 'inherit', textDecoration: 'none' }}
+              to={`/lesson/${lesson.id}`}
+            >
+              {lesson.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </Box>
+  )
+}
+
+export default LessonList

--- a/src/containers/my-resources/lesson-list/resource-service.mock.ts
+++ b/src/containers/my-resources/lesson-list/resource-service.mock.ts
@@ -1,0 +1,36 @@
+import { Lesson } from '~/types/my-resources/types/lesson.types'
+
+const lessons: Lesson[] = [
+  {
+    id: '1',
+    title: 'Lesson 1',
+    description: 'Description for Lesson 1'
+  },
+  {
+    id: '2',
+    title: 'Lesson 2',
+    description: 'Description for Lesson 2'
+  },
+  {
+    id: '3',
+    title: 'Lesson 3',
+    description: 'Description for Lesson 3'
+  },
+  {
+    id: '4',
+    title: 'Lesson 4',
+    description: 'Description for Lesson 4'
+  }
+]
+
+export const ResourceServiceMock = {
+  getLessons: async (): Promise<Lesson[]> => {
+    return new Promise((resolve) => setTimeout(() => resolve(lessons), 1000))
+  },
+  getLesson: async (id: string): Promise<Lesson | null> => {
+    const lesson = lessons.find((lesson) => lesson.id === id)
+    return new Promise((resolve) =>
+      setTimeout(() => resolve(lesson || null), 500)
+    )
+  }
+}

--- a/src/pages/my-resources/MyResources.tsx
+++ b/src/pages/my-resources/MyResources.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography'
 import { tabsData } from '~/pages/my-resources/MyResources.constants'
 import { styles } from '~/pages/my-resources/MyResources.styles'
 import TabNavigation from '~/components/tab-navigation/TabNavigation'
+import LessonList from '~/containers/my-resources/lesson-list/LessonList'
 
 const MyResources = () => {
   const [activeTab, setActiveTab] = useState<string>('lessons')
@@ -28,6 +29,7 @@ const MyResources = () => {
         tabsData={tabsData}
       />
       {tabContent}
+      {activeTab === 'lessons' && <LessonList />}
     </PageWrapper>
   )
 }

--- a/src/router/constants/authRoutes.ts
+++ b/src/router/constants/authRoutes.ts
@@ -8,6 +8,12 @@ export const authRoutes = {
   userProfile: { route: 'user/:id', path: '/user' },
   myResources: {
     root: { route: 'my-resources', path: '/my-resources' },
+    lessons: { route: 'lessons', path: '/lessons' },
+    lessonDetail: { route: 'lesson/:lessonId', path: '/lesson/:lessonId' },
+    createOrEditLesson: {
+      route: 'edit-lesson/:lessonId',
+      path: '/edit-lesson/:lessonId'
+    },
     newQuestion: {
       route: 'my-resources/new-question',
       path: '/my-resources/new-question'

--- a/src/router/routes/authRouter.tsx
+++ b/src/router/routes/authRouter.tsx
@@ -15,6 +15,8 @@ import {
 import PrivateRoute from '~/router/helpers/PrivateRoute'
 import { UserRoleEnum } from '~/types'
 import { userProfileLoader } from '../constants/loaders'
+import LessonList from '~/containers/my-resources/lesson-list/LessonList'
+import LessonDetail from '~/containers/my-resources/lesson-detail/LessonDetail'
 
 const Categories = lazy(() => import('~/pages/categories/Categories'))
 const Subjects = lazy(() => import('~/pages/subjects/Subjects'))
@@ -70,6 +72,21 @@ export const authRouter = (
       element={<CreateOrEditQuestion />}
       handle={{ crumb: [myResources, editQuestion] }}
       path={authRoutes.myResources.editQuestion.route}
+    />
+    <Route
+      element={<LessonList />}
+      handle={{ crumb: myResources }}
+      path={authRoutes.myResources.lessons.route}
+    />
+    <Route
+      element={<LessonDetail />}
+      handle={{ crumb: myResources }}
+      path={authRoutes.myResources.lessonDetail.route}
+    />
+    <Route
+      element={<CreateOrEditQuestion />}
+      handle={{ crumb: [myResources, editQuestion] }}
+      path={authRoutes.myResources.createOrEditLesson.path}
     />
   </Route>
 )

--- a/src/tests/unit/containers/my-resources/LessonDetail.spec.jsx
+++ b/src/tests/unit/containers/my-resources/LessonDetail.spec.jsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { vi } from 'vitest'
+import { ResourceServiceMock as ResourceService } from '~/containers/my-resources/lesson-list/resource-service.mock'
+import LessonDetail from '~/containers/my-resources/lesson-detail/LessonDetail'
+import '@testing-library/jest-dom'
+
+vi.mock('~/containers/my-resources/lesson-list/resource-service.mock')
+
+describe('LessonDetail', () => {
+  it('displays the loader initially', () => {
+    render(
+      <MemoryRouter initialEntries={['/lesson/1']}>
+        <Routes>
+          <Route element={<LessonDetail />} path='/lesson/:lessonId' />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('loader')).toBeInTheDocument()
+  })
+
+  it('displays the lesson details after fetching', async () => {
+    const lesson = {
+      id: '1',
+      title: 'Lesson 1',
+      description: 'Description for Lesson 1'
+    }
+    ResourceService.getLesson.mockResolvedValueOnce(lesson)
+
+    render(
+      <MemoryRouter initialEntries={['/lesson/1']}>
+        <Routes>
+          <Route element={<LessonDetail />} path='/lesson/:lessonId' />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Lesson 1')).toBeInTheDocument()
+      expect(screen.getByText('Description for Lesson 1')).toBeInTheDocument()
+    })
+  })
+
+  it('redirects to the edit page when clicking the title', async () => {
+    const lesson = {
+      id: '1',
+      title: 'Lesson 1',
+      description: 'Description for Lesson 1'
+    }
+    ResourceService.getLesson.mockResolvedValueOnce(lesson)
+
+    render(
+      <MemoryRouter initialEntries={['/lesson/1']}>
+        <Routes>
+          <Route element={<LessonDetail />} path='/lesson/:lessonId' />
+          <Route element={<div>Edit Page</div>} path='/edit-lesson/:lessonId' />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Lesson 1')).toBeInTheDocument()
+    })
+
+    screen.getByText('Lesson 1').click()
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Page')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/tests/unit/containers/my-resources/LessonList.spec.jsx
+++ b/src/tests/unit/containers/my-resources/LessonList.spec.jsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { vi } from 'vitest'
+import { ResourceServiceMock as ResourceService } from '~/containers/my-resources/lesson-list/resource-service.mock'
+import LessonList from '~/containers/my-resources/lesson-list/LessonList'
+import '@testing-library/jest-dom'
+
+vi.mock('~/containers/my-resources/lesson-list/resource-service.mock')
+
+describe('LessonList', () => {
+  it('displays the loader initially', () => {
+    render(
+      <MemoryRouter initialEntries={['/lessons']}>
+        <Routes>
+          <Route element={<LessonList />} path='/lessons' />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('loader')).toBeInTheDocument()
+  })
+
+  it('displays the list of lessons after fetching', async () => {
+    const lessons = [
+      { id: '1', title: 'Lesson 1', description: 'Description for Lesson 1' },
+      { id: '2', title: 'Lesson 2', description: 'Description for Lesson 2' }
+    ]
+    ResourceService.getLessons.mockResolvedValueOnce(lessons)
+
+    render(
+      <MemoryRouter initialEntries={['/lessons']}>
+        <Routes>
+          <Route element={<LessonList />} path='/lessons' />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Lesson 1')).toBeInTheDocument()
+      expect(screen.getByText('Lesson 2')).toBeInTheDocument()
+    })
+  })
+
+  it('redirects to the lesson detail page when clicking a title', async () => {
+    const lessons = [
+      { id: '1', title: 'Lesson 1', description: 'Description for Lesson 1' },
+      { id: '2', title: 'Lesson 2', description: 'Description for Lesson 2' }
+    ]
+    ResourceService.getLessons.mockResolvedValueOnce(lessons)
+
+    render(
+      <MemoryRouter initialEntries={['/lessons']}>
+        <Routes>
+          <Route element={<LessonList />} path='/lessons' />
+          <Route
+            element={<div>Lesson Detail Page</div>}
+            path='/lesson/:lessonId'
+          />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Lesson 1')).toBeInTheDocument()
+    })
+
+    screen.getByText('Lesson 1').click()
+
+    await waitFor(() => {
+      expect(screen.getByText('Lesson Detail Page')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/types/my-resources/types/lesson.types.ts
+++ b/src/types/my-resources/types/lesson.types.ts
@@ -1,0 +1,5 @@
+export interface Lesson {
+  id: string
+  title: string
+  description?: string
+}


### PR DESCRIPTION
## Result
https://github.com/user-attachments/assets/9062331c-3c24-47ec-a65e-6a4b8bee86cc

## Tests
<img width="830" alt="Знімок екрана 2024-08-06 о 15 02 00" src="https://github.com/user-attachments/assets/8a28b50a-0caa-45c9-b309-97e912043df0">
<img width="833" alt="Знімок екрана 2024-08-06 о 15 02 31" src="https://github.com/user-attachments/assets/a0f78bb8-02f9-4872-b407-53ff8b412d6c">

- [ ] Lesson Selection:

Added clickable lesson titles in the lesson management interface that redirect to a detailed view page.

- [ ] Lesson Detail View:

Created a component to display lesson details including title and description.

- [ ] Edit Redirection:

Made lesson titles clickable links that navigate to the /edit-lesson/:lessonId route for editing.

- [ ] Testing:

Verified that clicking on a lesson title redirects to the correct editing page and includes the lesson's unique ID.
Ensured seamless integration with existing lesson management and edit functionalities.