### PR TITLE
Create view for current Quiz

### DIFF
--- a/src/containers/my-resources/quiz-detail/QuizDetail.tsx
+++ b/src/containers/my-resources/quiz-detail/QuizDetail.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { QuizServiceMock } from './quiz-service.mock'
+import Loader from '~/components/loader/Loader'
+import { Quiz } from '~/types'
+import { Box, Typography } from '@mui/material'
+import { styles } from '~/containers/my-resources/add-resource-modal/AddResourceModal.styles'
+
+const QuizDetail = () => {
+  const { t } = useTranslation()
+  const { quizId } = useParams<{ quizId: string }>()
+  const [quiz, setQuiz] = useState<Quiz | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    const fetchQuiz = async () => {
+      if (quizId) {
+        try {
+          const fetchedQuiz: Quiz | null = await QuizServiceMock.getQuiz(quizId)
+          setQuiz(fetchedQuiz)
+        } catch (error: unknown) {
+          console.error('Error fetching quiz:', error)
+        } finally {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchQuiz().catch((error: unknown) => console.error(error))
+  }, [quizId])
+
+  if (loading) {
+    return <Loader pageLoad />
+  }
+
+  if (!quiz) {
+    return <div>{t('quizzes.noQuizFound')}</div>
+  }
+
+  return (
+    <Box sx={styles.root}>
+      <Typography sx={styles.title} variant='h1'>
+        <Link
+          style={{ textDecoration: 'none', color: 'inherit' }}
+          to={`/edit-quiz/${quiz._id}`}
+        >
+          {quiz.title}
+        </Link>
+      </Typography>
+      {quiz.description && (
+        <Typography sx={styles.root} variant='body1'>
+          {quiz.description}
+        </Typography>
+      )}
+    </Box>
+  )
+}
+
+export default QuizDetail

--- a/src/containers/my-resources/quiz-detail/quiz-service.mock.ts
+++ b/src/containers/my-resources/quiz-detail/quiz-service.mock.ts
@@ -1,0 +1,34 @@
+import { Category, Quiz } from '~/types'
+
+const quizzes: Quiz[] = [
+  {
+    _id: '1',
+    title: 'Quiz 1',
+    description: 'Description for Quiz 1',
+    category: { _id: '1', name: 'Category 1' } as Category,
+    items: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  },
+  {
+    _id: '2',
+    title: 'Quiz 2',
+    description: 'Description for Quiz 2',
+    category: { _id: '2', name: 'Category 2' } as Category,
+    items: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  }
+]
+
+export const QuizServiceMock = {
+  getQuizzes: async (): Promise<Quiz[]> => {
+    return new Promise((resolve) => setTimeout(() => resolve(quizzes), 1000))
+  },
+  getQuiz: async (id: string): Promise<Quiz | null> => {
+    const quiz = quizzes.find((quiz) => quiz._id === id)
+    return new Promise((resolve) =>
+      setTimeout(() => resolve(quiz || null), 500)
+    )
+  }
+}

--- a/src/containers/my-resources/quiz-list/QuizList.tsx
+++ b/src/containers/my-resources/quiz-list/QuizList.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import Loader from '~/components/loader/Loader'
+import { Quiz } from '~/types'
+import { Box } from '@mui/material'
+import { styles } from '~/containers/my-resources/add-resource-modal/AddResourceModal.styles'
+import { QuizServiceMock } from '../quiz-detail/quiz-service.mock'
+
+const QuizList = () => {
+  const [quizzes, setQuizzes] = useState<Quiz[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchQuizzes = async () => {
+      try {
+        const fetchedQuizzes: Quiz[] = await QuizServiceMock.getQuizzes()
+        setQuizzes(fetchedQuizzes)
+      } catch (error) {
+        console.error('Error fetching quizzes:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchQuizzes().catch(console.error)
+  }, [])
+
+  if (loading) {
+    return <Loader pageLoad />
+  }
+
+  return (
+    <Box sx={styles.root}>
+      <ul>
+        {quizzes.map((quiz) => (
+          <li key={quiz._id}>
+            <Link
+              style={{ color: 'inherit', textDecoration: 'none' }}
+              to={`/quiz/${quiz._id}`}
+            >
+              {quiz.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </Box>
+  )
+}
+
+export default QuizList

--- a/src/pages/my-resources/MyResources.tsx
+++ b/src/pages/my-resources/MyResources.tsx
@@ -8,6 +8,7 @@ import { tabsData } from '~/pages/my-resources/MyResources.constants'
 import { styles } from '~/pages/my-resources/MyResources.styles'
 import TabNavigation from '~/components/tab-navigation/TabNavigation'
 import LessonList from '~/containers/my-resources/lesson-list/LessonList'
+import QuizList from '~/containers/my-resources/quiz-list/QuizList'
 
 const MyResources = () => {
   const [activeTab, setActiveTab] = useState<string>('lessons')
@@ -30,6 +31,7 @@ const MyResources = () => {
       />
       {tabContent}
       {activeTab === 'lessons' && <LessonList />}
+      {activeTab === 'quizzes' && <QuizList />}
     </PageWrapper>
   )
 }

--- a/src/router/constants/authRoutes.ts
+++ b/src/router/constants/authRoutes.ts
@@ -25,6 +25,11 @@ export const authRoutes = {
     editQuestion: {
       route: 'my-resources/edit-question/:id',
       path: '/my-resources/edit-question'
+    },
+    quizzes: {
+      root: { route: 'quizzes', path: '/quizzes' },
+      detail: { route: 'quiz/:quizId', path: '/quiz/:quizId' },
+      edit: { route: 'edit-quiz/:quizId', path: '/edit-quiz/:quizId' }
     }
   },
   accountMenu: {

--- a/src/router/routes/authRouter.tsx
+++ b/src/router/routes/authRouter.tsx
@@ -18,6 +18,7 @@ import { UserRoleEnum } from '~/types'
 import { userProfileLoader } from '../constants/loaders'
 import LessonList from '~/containers/my-resources/lesson-list/LessonList'
 import LessonDetail from '~/containers/my-resources/lesson-detail/LessonDetail'
+import QuizDetail from '~/containers/my-resources/quiz-detail/QuizDetail'
 
 const Categories = lazy(() => import('~/pages/categories/Categories'))
 const Subjects = lazy(() => import('~/pages/subjects/Subjects'))
@@ -95,6 +96,16 @@ export const authRouter = (
       element={<CreateOrEditQuestion />}
       handle={{ crumb: [myResources, editQuestion] }}
       path={authRoutes.myResources.createOrEditLesson.path}
+    />
+    <Route
+      element={<QuizDetail />}
+      handle={{ crumb: myResources }}
+      path={authRoutes.myResources.quizzes.detail.path}
+    />
+    <Route
+      element={<CreateOrEditQuestion />}
+      handle={{ crumb: [myResources, editQuestion] }}
+      path={authRoutes.myResources.quizzes.edit.path}
     />
   </Route>
 )

--- a/src/tests/unit/containers/my-resources/QuizDetail.spec.jsx
+++ b/src/tests/unit/containers/my-resources/QuizDetail.spec.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import QuizDetail from '~/containers/my-resources/quiz-detail/QuizDetail'
+import { vi } from 'vitest'
+
+vi.mock('~/containers/my-resources/quiz-detail/quiz-service.mock', () => ({
+  QuizServiceMock: {
+    getQuiz: vi.fn().mockResolvedValue({
+      _id: '1',
+      title: 'Quiz 1',
+      description: 'Description for Quiz 1'
+    })
+  }
+}))
+
+test('renders quiz details and link to edit quiz', async () => {
+  render(
+    <MemoryRouter initialEntries={['/quiz/1']}>
+      <Routes>
+        <Route element={<QuizDetail />} path='/quiz/:quizId' />
+        <Route element={<div>Edit Quiz</div>} path='/edit-quiz/:quizId' />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  await waitFor(() => {
+    screen.debug()
+  })
+
+  const quizTitle = await screen.findByText('Quiz 1')
+  const quizDescription = await screen.findByText('Description for Quiz 1')
+
+  expect(quizTitle).toBeInTheDocument()
+  expect(quizDescription).toBeInTheDocument()
+
+  const editLink = screen.getByText('Quiz 1').closest('a')
+  expect(editLink).toHaveAttribute('href', '/edit-quiz/1')
+})

--- a/src/tests/unit/containers/my-resources/QuizList.spec.jsx
+++ b/src/tests/unit/containers/my-resources/QuizList.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { BrowserRouter as Router } from 'react-router-dom'
+import QuizList from '~/containers/my-resources/quiz-list/QuizList'
+import { vi } from 'vitest'
+
+vi.mock('~/containers/my-resources/quiz-detail/quiz-service.mock', () => ({
+  QuizServiceMock: {
+    getQuizzes: vi.fn().mockResolvedValue([
+      { _id: '1', title: 'Quiz 1', description: 'Description for Quiz 1' },
+      { _id: '2', title: 'Quiz 2', description: 'Description for Quiz 2' }
+    ])
+  }
+}))
+
+test('renders quiz titles and links to quiz details', async () => {
+  render(
+    <Router>
+      <QuizList />
+    </Router>
+  )
+
+  const quizLink1 = await screen.findByText('Quiz 1')
+  const quizLink2 = await screen.findByText('Quiz 2')
+
+  expect(quizLink1.closest('a')).toHaveAttribute('href', '/quiz/1')
+  expect(quizLink2.closest('a')).toHaveAttribute('href', '/quiz/2')
+})

--- a/src/types/quizzes/interfaces/quizzes.interface.ts
+++ b/src/types/quizzes/interfaces/quizzes.interface.ts
@@ -6,6 +6,7 @@ import {
 } from '~/types'
 
 export interface Quiz extends CommonEntityFields {
+  _id: string
   title: string
   description: string
   items: Question[]


### PR DESCRIPTION
## Result 
The objective is to introduce a detailed view for existing quizzes within our quiz management system, enhancing the overall user experience by allowing users to view quiz details seamlessly. A significant part of this functionality includes enabling users to redirect to the quiz editing page by clicking on the quiz title.


https://github.com/user-attachments/assets/e7f798a5-3c55-4bc3-8b0e-e998175680b5



## Tests

- [ ] Verified that clicking on the quiz title redirects to the correct editing page.

- [ ] Ensured integration with the existing quiz management system without introducing bugs or regressions.

<img width="787" alt="Знімок екрана 2024-08-12 о 18 14 10" src="https://github.com/user-attachments/assets/e69483c0-e1ef-4b38-8500-4089e29dbbb4">
<img width="802" alt="Знімок екрана 2024-08-12 о 18 24 58" src="https://github.com/user-attachments/assets/d8523fc1-a3b8-4dcd-b89b-45760332b957">

